### PR TITLE
remove the rls component from install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     # Install Rust components
     && rustup default nightly \
     && rustup update 2>&1 \
-    && rustup component add rls rust-analysis rust-src rustfmt 2>&1 \
+    && rustup component add rust-analysis rust-src rustfmt 2>&1 \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
RLS component was removed from the nightly build (I'm guessing because of the move to rust-analyzer), but we weren't using it anyways.